### PR TITLE
serve *.js.map as assets

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -32,6 +32,7 @@ export default {
 
   assetExtensions: [
     'js',
+    'js.map',
     'css',
     'png',
     'jpe?g',


### PR DESCRIPTION
Enables SourceMaps to work correctly.
